### PR TITLE
Fix metadata of Genres and Season Image

### DIFF
--- a/Jellyfin.Plugin.OpenDouban/Providers/ExternalId/OddbSeriesExternalId.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/ExternalId/OddbSeriesExternalId.cs
@@ -1,0 +1,27 @@
+
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace Jellyfin.Plugin.OpenDouban.Providers.ExternalId
+{
+    /// <inheritdoc />
+    public class OddbSeriesExternalId : IExternalId
+    {
+        /// <inheritdoc />
+        public string ProviderName => OddbPlugin.ProviderName;
+
+        /// <inheritdoc />
+        public string Key => OddbPlugin.ProviderId;
+
+        /// <inheritdoc />
+        public ExternalIdMediaType? Type => ExternalIdMediaType.Series;
+
+        /// <inheritdoc />
+        public string UrlFormatString => "https://movie.douban.com/subject/{0}/";
+
+        /// <inheritdoc />
+        public bool Supports(IHasProviderIds item) => item is Series;
+    }
+}

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbImageProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbImageProvider.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
         public string Name => OddbPlugin.ProviderName;
 
         /// <inheritdoc />
-        public bool Supports(BaseItem item) => item is Movie || item is Series;
+        public bool Supports(BaseItem item) => item is Movie || item is Series || item is Season;
 
         /// <inheritdoc />
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item) => new List<ImageType>

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbImageProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbImageProvider.cs
@@ -99,6 +99,11 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
             var photo = await _oddbApiClient.GetPhotoBySid(sid);
             var list = new List<RemoteImageInfo>();
 
+            if(photo == null) 
+            {
+                return list;
+            }
+
             return photo.Where(x => x.Width > x.Height * 1.3).Select(x => 
             {
                 return new RemoteImageInfo

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbMovieProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbMovieProvider.cs
@@ -135,6 +135,7 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
                 Overview = x?.Intro,
                 ProductionYear = x?.Year,
                 HomePageUrl = "https://www.douban.com",
+                Genres = x?.Genre.Split("/").Select(x => x.Trim()).ToArray(),
                 // ProductionLocations = [x?.Country],
                 // PremiereDate = null,
             };

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbSeasonProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbSeasonProvider.cs
@@ -102,6 +102,7 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
                 Overview = x?.Intro,
                 ProductionYear = x?.Year,
                 HomePageUrl = "https://www.douban.com",
+                Genres = x?.Genre.Split("/").Select(x => x.Trim()).ToArray(),
                 // ProductionLocations = [x?.Country],
                 // PremiereDate = null,   
             };

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbSeriesProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbSeriesProvider.cs
@@ -136,6 +136,7 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
                 Overview = x?.Intro,
                 ProductionYear = x?.Year,
                 HomePageUrl = "https://www.douban.com",
+                Genres = x?.Genre.Split("/").Select(x => x.Trim()).ToArray(),
                 // ProductionLocations = [x?.Country],
                 // PremiereDate = null,   
             };


### PR DESCRIPTION
It comes from https://github.com/caryyu/jellyfin-plugin-opendouban/issues/12

1. Support Genres
2. Support Season's image download
3. Support Series ExternalId
4. Fix backdrop if 404 encounters
