### PR TITLE
Bugfixes: OriginalTitle & PremiereDate

### DIFF
--- a/Jellyfin.Plugin.OpenDouban.Tests/Providers/OddbMovieProviderTest.cs
+++ b/Jellyfin.Plugin.OpenDouban.Tests/Providers/OddbMovieProviderTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using MediaBrowser.Controller.Providers;
@@ -59,8 +60,9 @@ namespace Jellyfin.Plugin.OpenDouban.Tests
             var meta = _provider.GetMetadata(info, CancellationToken.None).Result;
             Assert.True(meta.HasMetadata);
             Assert.Equal("源代码", meta.Item.Name);
+            Assert.Equal("Source Code", meta.Item.OriginalTitle);
             Assert.Equal("3075287", meta.Item.GetProviderId(OddbPlugin.ProviderId));
-            // Assert.Equal(DateTime.Parse("2011-08-30"), meta.Item.PremiereDate);
+            Assert.Equal(DateTime.Parse("2011-08-30"), meta.Item.PremiereDate);
 
             // Test 2: Already has provider Id.
             info = new MovieInfo()

--- a/Jellyfin.Plugin.OpenDouban/OddbApiClient.cs
+++ b/Jellyfin.Plugin.OpenDouban/OddbApiClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -169,6 +170,21 @@ namespace Jellyfin.Plugin.OpenDouban
         public string Language { get; set; }
         // "screen": "2002-01-26(中国大陆) / 2020-08-14(中国大陆重映) / 2001-11-04(英国首映) / 2001-11-16(美国)",
         public string Screen { get; set; }
+        public DateTime? ScreenTime
+        {
+            get
+            {
+                var items = Screen.Split("/");
+                if (items.Length >= 0)
+                {
+                    var item = items[0].Split("(")[0];
+                    DateTime result;
+                    DateTime.TryParseExact(item, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out result);
+                    return result;
+                }
+                return null;
+            }
+        }
         // "duration": "152分钟 / 159分钟(加长版)",
         public string Duration { get; set; }
         // "subname": "哈利波特1：神秘的魔法石(港/台) / 哈1 / Harry Potter and the Philosopher's Stone",

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbMovieProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbMovieProvider.cs
@@ -130,14 +130,14 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
             {
                 ProviderIds = new Dictionary<string, string> { { OddbPlugin.ProviderId, x.Sid } },
                 Name = x?.Name,
-                OriginalTitle = x?.Subname,
+                OriginalTitle = x?.OriginalName,
                 CommunityRating = x?.Rating,
                 Overview = x?.Intro,
                 ProductionYear = x?.Year,
                 HomePageUrl = "https://www.douban.com",
                 Genres = x?.Genre.Split("/").Select(x => x.Trim()).ToArray(),
                 // ProductionLocations = [x?.Country],
-                // PremiereDate = null,
+                PremiereDate = x?.ScreenTime,
             };
 
             info.SetProviderId(OddbPlugin.ProviderId, x.Sid);

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbSeasonProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbSeasonProvider.cs
@@ -98,14 +98,14 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
             {
                 ProviderIds = new Dictionary<string, string> { { OddbPlugin.ProviderId, x.Sid } },
                 Name = x?.Name,
-                OriginalTitle = x?.Subname,
+                OriginalTitle = x?.OriginalName,
                 CommunityRating = x?.Rating,
                 Overview = x?.Intro,
                 ProductionYear = x?.Year,
                 HomePageUrl = "https://www.douban.com",
                 Genres = x?.Genre.Split("/").Select(x => x.Trim()).ToArray(),
                 // ProductionLocations = [x?.Country],
-                // PremiereDate = null,   
+                PremiereDate = x?.ScreenTime,   
             };
 
             info.SetProviderId(OddbPlugin.ProviderId, x.Sid);

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbSeriesProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbSeriesProvider.cs
@@ -131,14 +131,14 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
             {
                 ProviderIds = new Dictionary<string, string> { { OddbPlugin.ProviderId, x.Sid } },
                 Name = x?.Name,
-                OriginalTitle = x?.Subname,
+                OriginalTitle = x?.OriginalName,
                 CommunityRating = x?.Rating,
                 Overview = x?.Intro,
                 ProductionYear = x?.Year,
                 HomePageUrl = "https://www.douban.com",
                 Genres = x?.Genre.Split("/").Select(x => x.Trim()).ToArray(),
                 // ProductionLocations = [x?.Country],
-                // PremiereDate = null,   
+                PremiereDate = x?.ScreenTime,   
             };
 
             info.SetProviderId(OddbPlugin.ProviderId, x.Sid);


### PR DESCRIPTION
There're two bugfixes referring to https://github.com/caryyu/jellyfin-plugin-opendouban/issues/16:

1. Original title should follow the second section of the title from Douban subject, for instance: `失控玩家 Free Guy`, the `Free Guy` will be taken 
2. Open premiere date by selecting the first index of the screen time from Douban subject, for instance: `2021-08-27(中国大陆) / 2021-08-10(洛迦诺电影节) / 2021-08-13(美国)`, the `2021-08-27` will be chosen