### PR TITLE
解决搜索时部分图片没法显示

### DIFF
--- a/Jellyfin.Plugin.OpenDouban/Jellyfin.Plugin.OpenDouban.csproj
+++ b/Jellyfin.Plugin.OpenDouban/Jellyfin.Plugin.OpenDouban.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbMovieProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbMovieProvider.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.OpenDouban.Providers.Utils;
 
 namespace Jellyfin.Plugin.OpenDouban.Providers
 {
@@ -87,7 +88,7 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
                 return new RemoteSearchResult
                 {
                     ProviderIds = new Dictionary<string, string> { { OddbPlugin.ProviderId, x.Sid } },
-                    ImageUrl = x?.Img,
+                    ImageUrl = ImageUtils.FixForbiddenImageDomain(x?.Img),
                     ProductionYear = x?.Year,
                     Name = x?.Name
                 };

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbSeasonProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbSeasonProvider.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.OpenDouban.Providers.Utils;
 
 namespace Jellyfin.Plugin.OpenDouban.Providers
 {
@@ -164,7 +165,7 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
                 return new RemoteSearchResult
                 {
                     ProviderIds = new Dictionary<string, string> { { OddbPlugin.ProviderId, x.Sid } },
-                    ImageUrl = x?.Img,
+                    ImageUrl = ImageUtils.FixForbiddenImageDomain(x?.Img),
                     ProductionYear = x?.Year,
                     Name = x?.Name
                 };

--- a/Jellyfin.Plugin.OpenDouban/Providers/OddbSeriesProvider.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/OddbSeriesProvider.cs
@@ -9,6 +9,7 @@ using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Providers;
 using Microsoft.Extensions.Logging;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.OpenDouban.Providers.Utils;
 
 namespace Jellyfin.Plugin.OpenDouban.Providers
 {
@@ -87,7 +88,7 @@ namespace Jellyfin.Plugin.OpenDouban.Providers
                 return new RemoteSearchResult
                 {
                     ProviderIds = new Dictionary<string, string> { { OddbPlugin.ProviderId, x.Sid } },
-                    ImageUrl = x?.Img,
+                    ImageUrl = ImageUtils.FixForbiddenImageDomain(x?.Img),
                     ProductionYear = x?.Year,
                     Name = x?.Name
                 };

--- a/Jellyfin.Plugin.OpenDouban/Providers/Utils/ImageUtils.cs
+++ b/Jellyfin.Plugin.OpenDouban/Providers/Utils/ImageUtils.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.OpenDouban.Providers.Utils
+{
+    class ImageUtils
+    {
+        private static Regex regImageDomain = new Regex(@"//img\d+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// 替换图片域为没防盗链的img2
+        /// </summary>
+        public static string FixForbiddenImageDomain(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return "";
+            }
+
+            return regImageDomain.Replace(url, "img2");
+        }
+    }
+}


### PR DESCRIPTION
搜索时因豆瓣图片域防盗链导致没法显示，替换为不防盗链的img2域


![](https://fastly.jsdelivr.net/gh/kozalak-robot/assets@main/img/1655118356434Xnip2022-06-13_19-04-26.png)